### PR TITLE
Use correct inflection for has-many counts of 1

### DIFF
--- a/app/views/fields/nested_has_many/_index.html.erb
+++ b/app/views/fields/nested_has_many/_index.html.erb
@@ -16,4 +16,4 @@ as a count of how many objects are associated through the relationship.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasMany
 %>
 
-<%= pluralize(field.data.size, field.attribute.to_s.humanize.downcase) %>
+<%= pluralize(field.data.size, field.attribute.to_s.humanize.singularize.downcase) %>


### PR DESCRIPTION
This fixes the issue where a has-many association with one record will be
displayed with a plural on index pages, ex: "1 orders", instead of "1
order".

Rails expects the second argument to the pluralize helper to be the
singular form of the word.

See: https://github.com/thoughtbot/administrate/pull/577
