### PR TITLE
Necessary fixes and some polishing

### DIFF
--- a/administrate-field-nested_has_many.gemspec
+++ b/administrate-field-nested_has_many.gemspec
@@ -15,9 +15,8 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency "administrate", "0.8.1"
+  gem.add_dependency "administrate", "~> 0.8", ">= 0.8.1"
   gem.add_dependency "cocoon", "~> 1.2", ">= 1.2.11"
-  gem.add_dependency "rails", "~> 5.1", ">= 5.1.4"
 
   gem.add_development_dependency "rspec"
 end

--- a/administrate-field-nested_has_many.gemspec
+++ b/administrate-field-nested_has_many.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency "administrate", "~> 0.2.1"
-  gem.add_dependency "cocoon", "~> 1.2"
-  gem.add_dependency "rails", "~> 4.2"
+  gem.add_dependency "administrate", "0.8.1"
+  gem.add_dependency "cocoon", "~> 1.2", ">= 1.2.11"
+  gem.add_dependency "rails", "~> 5.1", ">= 5.1.4"
 
   gem.add_development_dependency "rspec"
 end

--- a/app/assets/stylesheets/administrate-field-nested_has_many/application.css
+++ b/app/assets/stylesheets/administrate-field-nested_has_many/application.css
@@ -1,0 +1,3 @@
+/*
+ *= require_tree .
+ */

--- a/app/assets/stylesheets/administrate-field-nested_has_many/base.scss
+++ b/app/assets/stylesheets/administrate-field-nested_has_many/base.scss
@@ -1,0 +1,14 @@
+@import 'administrate/library/variables';
+@import 'administrate/library/clearfix';
+
+.field-unit--nested-has-many {
+  .nested-fields {
+    @include administrate-clearfix;
+    margin-bottom: $base-spacing;
+    padding-bottom: $base-spacing;
+  }
+
+  .remove_fields, .add_fields {
+    float: right;
+  }
+}

--- a/app/views/fields/nested_has_many/_fields.html.erb
+++ b/app/views/fields/nested_has_many/_fields.html.erb
@@ -6,6 +6,5 @@
     </div>
   <% end -%>
 
-  <%# TODO I18n %>
-  <%= link_to_remove_association "Remove #{field.associated_class_name.titleize}", f %>
+  <%= link_to_remove_association I18n.t("administrate.fields.nested_has_many.remove", resource: field.associated_class_name.titleize), f %>
 </div>

--- a/app/views/fields/nested_has_many/_fields.html.erb
+++ b/app/views/fields/nested_has_many/_fields.html.erb
@@ -1,6 +1,5 @@
-<div class="nested-fields" style="width:100%">
-
-  <% field.nested_fields.each do |attribute| -%>
+<div class="nested-fields">
+  <% field.nested_fields_for_builder(f).each do |attribute| -%>
     <div class="field-unit field-unit--<%= attribute.html_class %>">
       <%= render_field attribute, f: f %>
     </div>

--- a/app/views/fields/nested_has_many/_form.html.erb
+++ b/app/views/fields/nested_has_many/_form.html.erb
@@ -12,8 +12,7 @@
 
   <div>
     <%= link_to_add_association(
-      # TODO I18n
-      "Add #{field.associated_class_name.titleize}",
+      I18n.t("administrate.fields.nested_has_many.add", resource: field.associated_class_name.titleize),
       f,
       field.association_name,
       class: 'button',

--- a/app/views/fields/nested_has_many/_form.html.erb
+++ b/app/views/fields/nested_has_many/_form.html.erb
@@ -1,13 +1,13 @@
-<div class="nested-fields" style="width: 40%; margin-left: 20%;">
-
+<fieldset class="field-unit--nested">
+  <legend><%= f.label field.attribute %></legend>
   <%= f.fields_for field.association_name do |nested_form| %>
-    <%= render(
-      partial: "fields/nested_has_many/fields",
-      locals: {
-        f: nested_form,
-        field: field,
-      },
-    ) %>
+      <%= render(
+        partial: "fields/nested_has_many/fields",
+        locals: {
+          f: nested_form,
+          field: field,
+        },
+      ) %>
   <% end %>
 
   <div>
@@ -16,8 +16,9 @@
       "Add #{field.associated_class_name.titleize}",
       f,
       field.association_name,
+      class: 'button',
       partial: "fields/nested_has_many/fields",
       render_options: { locals: { field: field } },
     ) %>
   </div>
-</div>
+</fieldset>

--- a/app/views/fields/nested_has_many/_show.html.erb
+++ b/app/views/fields/nested_has_many/_show.html.erb
@@ -22,7 +22,8 @@ from the associated resource class's dashboard.
   <%= render(
     "collection",
     collection_presenter: field.associated_collection,
-    resources: field.resources
+    resources: field.resources,
+    table_title: field.name    
   ) %>
 
   <% if field.more_than_limit? %>
@@ -36,5 +37,5 @@ from the associated resource class's dashboard.
   <% end %>
 
 <% else %>
-  <%= t("administrate.fields.has_many.none") %>
+  <%= t("administrate.fields.has_many.none", default: "–") %>
 <% end %>

--- a/config/locales/administrate-field-nested_has_many.en.yml
+++ b/config/locales/administrate-field-nested_has_many.en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  administrate:
+    fields:
+      nested_has_many:
+        add: "Add %{resource}"
+        remove: "Remove %{resource}"

--- a/lib/administrate/field/nested_has_many.rb
+++ b/lib/administrate/field/nested_has_many.rb
@@ -24,6 +24,21 @@ module Administrate
         end
       end
 
+      def nested_fields_for_builder(form_builder)
+        return nested_fields unless form_builder.index.is_a? Integer
+
+        nested_fields.each do |nested_field|
+          next if nested_field.resource.blank?
+
+          # inject current data into field
+          resource = nested_field.resource[form_builder.index]
+          nested_field.instance_variable_set(
+            "@data",
+            resource.send(nested_field.attribute),
+          )
+        end
+      end
+
       def to_s
         data
       end
@@ -53,7 +68,7 @@ module Administrate
       end
 
       def associated_form
-        Administrate::Page::Form.new(associated_dashboard, association_name)
+        Administrate::Page::Form.new(associated_dashboard, data)
       end
 
       private

--- a/lib/administrate/field/nested_has_many.rb
+++ b/lib/administrate/field/nested_has_many.rb
@@ -8,10 +8,15 @@ module Administrate
   module Field
     class NestedHasMany < Administrate::Field::HasMany
       class Engine < ::Rails::Engine
-        Administrate::Engine.add_javascript "administrate-field-nested_has_many/application"
+        Administrate::Engine.add_javascript(
+          "administrate-field-nested_has_many/application",
+        )
+        Administrate::Engine.add_stylesheet(
+          "administrate-field-nested_has_many/application",
+        )
       end
 
-      DEFAULT_ATTRIBUTES = [:id, :_destroy].freeze
+      DEFAULT_ATTRIBUTES = %i(id _destroy).freeze
 
       def nested_fields
         associated_form.attributes.reject do |nested_field|


### PR DESCRIPTION
I could't even install the current version at first. Detected it was because the gemspec had an unnecessary dependancy of "coccon", so If "coccon" wasn't already installed on the computer the installation of this gem would also fail. That has been fixed as well as:

- Made some minor polishing on styling. It is now more consistent with nested has_one forms
- The "Add" and "Remove" buttons are now translatable
- Removed unnecessary Rails dependency
- Updated administrate dependency
