### PR TITLE
Fixes for Administrate 0.9

### DIFF
--- a/administrate-field-nested_has_many.gemspec
+++ b/administrate-field-nested_has_many.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency "administrate", "~> 0.8", ">= 0.8.1"
+  gem.add_dependency "administrate", "> 0.8", "< 1"
   gem.add_dependency "cocoon", "~> 1.2", ">= 1.2.11"
 
   gem.add_development_dependency "rspec"

--- a/lib/administrate/field/nested_has_many.rb
+++ b/lib/administrate/field/nested_has_many.rb
@@ -52,7 +52,7 @@ module Administrate
           dashboard_for_resource(associated_resource).new.permitted_attributes
       end
 
-      def self.permitted_attribute(associated_resource)
+      def self.permitted_attribute(associated_resource, _options = nil)
         {
           "#{associated_resource}_attributes".to_sym =>
           associated_attributes(associated_resource),


### PR DESCRIPTION
I based this work on @baldursson's #10, as it solves many of the issues in the current state.

Included relaxation of constraints on the gemspec to allow for Administrate 0.9 and also a fix for a small change on `.permitted_parameters`.

Let me know what is needed to get this upstream, as I'd prefer to use Rubygems instead of a fork on my Gemfile.

PR #10 is essential anyway, so feel free if you want to merge that separately first.

Thanks for the gem, it helps a lot!