### PR TITLE
Adapt to changes in Administrate's templates

### DIFF
--- a/app/views/fields/nested_has_many/_show.html.erb
+++ b/app/views/fields/nested_has_many/_show.html.erb
@@ -19,11 +19,15 @@ from the associated resource class's dashboard.
 %>
 
 <% if field.resources.any? %>
+  <% order = field.order_from_params(params.fetch(field.name, {})) %>
+  <% page_number = params.fetch(field.name, {}).fetch(:page, nil) %>
   <%= render(
     "collection",
-    collection_presenter: field.associated_collection,
-    resources: field.resources,
-    table_title: field.name    
+    collection_presenter: field.associated_collection(order),
+    collection_field_name: field.name,
+    page: page,
+    resources: field.resources(page_number, order),
+    table_title: field.name,
   ) %>
 
   <% if field.more_than_limit? %>


### PR DESCRIPTION
https://github.com/thoughtbot/administrate/pull/945 was recently merged into Administrate. This introduced some template changes, one of which breaks this plugin.

The proposed change should fix this.