### PR TITLE
Support namespaced models

### DIFF
--- a/administrate-field-nested_has_many.gemspec
+++ b/administrate-field-nested_has_many.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "appraisal"
   gem.add_development_dependency "capybara"
+  gem.add_development_dependency "selenium-webdriver"
   gem.add_development_dependency "factory_bot"
   gem.add_development_dependency "i18n-tasks"
   gem.add_development_dependency "rake"

--- a/spec/dummy/app/controllers/admin/foo/students_controller.rb
+++ b/spec/dummy/app/controllers/admin/foo/students_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class StudentsController < Admin::ApplicationController
+  class Foo::StudentsController < Admin::ApplicationController
     # To customize the behavior of this controller,
     # you can overwrite any of the RESTful actions. For example:
     #

--- a/spec/dummy/app/dashboards/foo/student_dashboard.rb
+++ b/spec/dummy/app/dashboards/foo/student_dashboard.rb
@@ -1,6 +1,6 @@
 require "administrate/base_dashboard"
 
-class StudentDashboard < Administrate::BaseDashboard
+class Foo::StudentDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #

--- a/spec/dummy/app/dashboards/school_dashboard.rb
+++ b/spec/dummy/app/dashboards/school_dashboard.rb
@@ -10,7 +10,7 @@ class SchoolDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     name: Field::String,
-    students: Field::NestedHasMany,
+    students: Field::NestedHasMany.with_options(class_name: "Foo::Student"),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze

--- a/spec/dummy/app/models/foo/student.rb
+++ b/spec/dummy/app/models/foo/student.rb
@@ -1,0 +1,3 @@
+class Foo::Student < ApplicationRecord
+  belongs_to :school
+end

--- a/spec/dummy/app/models/school.rb
+++ b/spec/dummy/app/models/school.rb
@@ -1,4 +1,4 @@
 class School < ApplicationRecord
-  has_many :students
+  has_many :students, class_name: "Foo::Student"
   accepts_nested_attributes_for :students
 end

--- a/spec/dummy/app/models/student.rb
+++ b/spec/dummy/app/models/student.rb
@@ -1,3 +1,0 @@
-class Student < ApplicationRecord
-  belongs_to :school
-end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   namespace :admin do
     root to: redirect("/admin/schools")
     resources :schools
-    resources :students
+    namespace :foo do
+      resources :students
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:name) { |i| "School ##{i}" }
   end
 
-  factory :student do
+  factory :student, class: Foo::Student do
     sequence(:name) { |i| "Student ##{i}" }
   end
 end

--- a/spec/features/has_many_spec.rb
+++ b/spec/features/has_many_spec.rb
@@ -9,13 +9,33 @@ feature "Has many" do
     FactoryBot.create(:student, name: "John Doe", school: school)
   end
 
-  scenario "index page" do
+  scenario "index" do
     visit admin_schools_path
     expect(page).to have_content("School of Life")
   end
 
-  scenario "show page" do
+  scenario "show" do
     visit admin_school_path(school)
     expect(page).to have_content("John Doe")
+  end
+
+  scenario "new" do
+    visit new_admin_school_path
+    expect(page).to have_content("New Schools")
+  end
+
+  scenario "create", js: true do
+    visit new_admin_school_path
+    expect(page).to have_content("New Schools")
+    expect(page).to have_content("Add Foo/Student")
+    fill_in "Name", with: "La Ferme du Bec Hellouin"
+    click_link "Add Foo/Student"
+    expect(page).to have_content("Remove Foo/Student")
+    within(".nested-fields") do
+      fill_in "Name", with: "Sébastien"
+    end
+    click_button "Create School"
+    expect(page).to have_text("La Ferme du Bec Hellouin")
+    expect(page).to have_text("Sébastien")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,8 @@ require 'rspec/rails'
 require 'factory_bot'
 require_relative './factories'
 
+Capybara.server = :webrick
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
Adds support for namespaced model associations:
- drops any namespace from the auto-inferred `association_name`. E.g `Post::Translation` will yield `translations` instead of the otherwise incorrect `post/translations`, which in turn was otherwise leading to the [error](https://github.com/nathanvda/cocoon/issues/569) in Cocoon `Undefined method 'new_record' for nil:NilClass`.
- allows to manually define the association name if the auto-inferred name is not yet correct
- fixes the inferred name of the associated model's dashboard class (should be `Post::TranslationDashboard` and not `TranslationDashboard`)

This is required when working with `PaperTrail` (`PaperTrail::Version`), `Globalize` (`Post::Translation`), or supposedly any other namespaced models. 

The association can be configured as follows:
```rb
# app/dashboards/post_dashboard.rb
class PostDashboard < Administrate::BaseDashboard
  ATTRIBUTE_TYPES = {
    translations: Field::NestedHasMany.with_options(class_name: "Post::Translation"),
    ...
  ]
end
```

Fixes https://github.com/nickcharlton/administrate-field-nested_has_many/issues/8.