### PR TITLE
Fix CI by explicitly setting a Postgres password

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,13 @@ jobs:
         environment:
           PGHOST: localhost
           PGUSER: administrate-field-nested_has_many
+          PGPASSWORD: administrate-field-nested_has_many
           RAILS_ENV: test
       - image: postgres:11
         environment:
           POSTGRES_USER: administrate-field-nested_has_many
           POSTGRES_DB: administrate-field-nested_has_many_test
-          POSTGRES_PASSWORD: ""
+          POSTGRES_PASSWORD: administrate-field-nested_has_many
     steps:
       - checkout
 


### PR DESCRIPTION
This was introduced in a point update to Postgres itself, and we're
scoping only to the major version.

https://discuss.circleci.com/t/postgresql-image-password-not-specified-issue/34555