### PR TITLE
We need to use a node-browsers to run features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     working_directory: ~/administrate-field-nested_has_many
     docker:
-      - image: circleci/ruby:2.6.3
+      - image: circleci/ruby:2.6.3-node-browsers
         environment:
           PGHOST: localhost
           PGUSER: administrate-field-nested_has_many


### PR DESCRIPTION
Without it, a browser isn't available to start up.