### PR TITLE
Fix undefined local variable or method `root_url'

### DIFF
--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root to: redirect("/admin/schools")
   namespace :admin do
     root to: redirect("/admin/schools")
     resources :schools


### PR DESCRIPTION
Fixes `ActionView::Template::Error: undefined local variable or method 'root_url' for #<#<Class:0x00007f90a03702e8>:0x00007f90a0379ca8>` with administrate 0.13.0 (due to https://github.com/thoughtbot/administrate/pull/1376).