### PR TITLE
Root route required by sidebar

### DIFF
--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root to: redirect("/admin/schools")
   namespace :admin do
     root to: redirect("/admin/schools")
     resources :schools


### PR DESCRIPTION
Since https://github.com/thoughtbot/administrate/pull/1376, Administrate requires a `root` route by default. Otherwise it raises the following:

```
ActionView::Template::Error (undefined local variable or method `root_url' for #<#<Class:0x000055d0d8b83f40>:0x000055d0d8b81380>):
     8: %>
     9: 
    10: <nav class="navigation" role="navigation">
    11:   <%= link_to "Back to app", root_url, class: "button button--alt" %> 
    12: 
    13:   <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
    14:     <%= link_to(
  
administrate (0.13.0) app/views/administrate/application/_navigation.html.erb:11
...
```

This PR adds this route, so that the dummy app can run.