### PR TITLE
Avoid having to add assets to the host manifest

### DIFF
--- a/lib/administrate/field/nested_has_many.rb
+++ b/lib/administrate/field/nested_has_many.rb
@@ -15,6 +15,13 @@ module Administrate
         Administrate::Engine.add_stylesheet(
           "administrate-field-nested_has_many/application",
         )
+
+        initializer "administrate-field-nested_has_many.assets.precompile" do |app|
+          app.config.assets.precompile += [
+            "administrate-field-nested_has_many/application.js",
+            "administrate-field-nested_has_many/application.css",
+          ]
+        end
       end
 
       DEFAULT_ATTRIBUTES = %i(id _destroy).freeze


### PR DESCRIPTION
Similar to https://github.com/thoughtbot/administrate/pull/1904, this PR sets the assets to precompile. This way, users won't have to list them in `manifest.js`.