### PR TITLE
Align #show pagination with 0.16.0

### DIFF
--- a/app/views/fields/nested_has_many/_show.html.erb
+++ b/app/views/fields/nested_has_many/_show.html.erb
@@ -31,13 +31,7 @@ from the associated resource class's dashboard.
   ) %>
 
   <% if field.more_than_limit? %>
-    <span>
-      <%= t(
-        'administrate.fields.has_many.more',
-        count: field.limit,
-        total_count: field.data.count,
-      ) %>
-    </span>
+    <%= paginate field.resources(page_number), param_name: "#{field.name}[page]" %>
   <% end %>
 <% else %>
   <%= t("administrate.fields.has_many.none", default: "–") %>

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -2,15 +2,18 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2018_09_07_104703) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "schools", force: :cascade do |t|
     t.string "name"
@@ -20,10 +23,11 @@ ActiveRecord::Schema.define(version: 2018_09_07_104703) do
 
   create_table "students", force: :cascade do |t|
     t.string "name"
-    t.integer "school_id"
+    t.bigint "school_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["school_id"], name: "index_students_on_school_id"
   end
 
+  add_foreign_key "students", "schools"
 end

--- a/spec/features/has_many_spec.rb
+++ b/spec/features/has_many_spec.rb
@@ -19,6 +19,16 @@ feature "Has many" do
     expect(page).to have_content("John Doe")
   end
 
+  scenario "pagination" do
+    FactoryBot.create_list(:student, 10, school: school)
+
+    visit admin_school_path(school)
+
+    expect(page.html).to have_css("nav[role=navigation]")
+    expect(page.html).to have_content("Last")
+    expect(page.html).to have_content("Next")
+  end
+
   scenario "new" do
     visit new_admin_school_path
     expect(page).to have_content("New Schools")


### PR DESCRIPTION
When viewing nested records of type `NestedHasMany` on a resource's #show page, "Showing x of y" is displayed instead of the pagination component (for lack of a better term).

**Before**
![Screen Shot 2021-07-29 at 4 06 02 PM](https://user-images.githubusercontent.com/968057/127565748-713feec4-614f-479f-9c6e-1f3c898d453f.png)

**After**
![Screen Shot 2021-07-29 at 4 10 00 PM](https://user-images.githubusercontent.com/968057/127566314-4b366040-7735-4f9e-a4d6-dfff6d7e3c41.png)


**Versions**
* administrate-field-nested_has_many on `master`
* administrate -v 0.16.0
* Rails -v 6.1.1
* Ruby -v 3.0.0