### PR TITLE
taking :skip in nested collection into account

### DIFF
--- a/lib/administrate/field/nested_has_many.rb
+++ b/lib/administrate/field/nested_has_many.rb
@@ -5,6 +5,8 @@ require "administrate/engine"
 require "administrate/version"
 require "cocoon"
 
+require "administrate/page/nested_collection"
+
 module Administrate
   module Field
     class NestedHasMany < Administrate::Field::HasMany
@@ -29,6 +31,12 @@ module Administrate
       def nested_fields
         associated_form.attributes.reject do |nested_field|
           skipped_fields.include?(nested_field.attribute)
+        end
+      end
+
+      def nested_attributes
+        associated_dashboard.collection_attributes.reject do |nested_attribute|
+          skipped_fields.include?(nested_attribute)
         end
       end
 
@@ -84,6 +92,10 @@ module Administrate
         options.fetch(:association_name) do
           associated_class_name.underscore.pluralize[/([^\/]*)$/, 1]
         end
+      end
+
+      def associated_collection(order = self.order)
+        Administrate::Page::NestedCollection.new(associated_dashboard, order: order, collection_attributes: nested_attributes)
       end
 
       def associated_form

--- a/lib/administrate/page/nested_collection.rb
+++ b/lib/administrate/page/nested_collection.rb
@@ -1,0 +1,11 @@
+require 'administrate/page/collection'
+
+module Administrate
+  module Page
+    class NestedCollection < Page::Collection
+      def attribute_names
+        options.fetch(:collection_attributes, dashboard.collection_attributes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This solves #12 by taking the `:skip` option into account while rendering nested collections. 

Currently i don't have time to implement tests. Maybe someone wants to volunteer? :)

Works as expected in our current implementation using v1.3.0