### PR TITLE
Instantiate new records from relation

### DIFF
--- a/lib/administrate/field/nested_has_many.rb
+++ b/lib/administrate/field/nested_has_many.rb
@@ -92,8 +92,12 @@ module Administrate
 
       private
 
+      def association
+        resource.send(self.association_name)
+      end
+
       def new_resource
-        @new_resource ||= associated_class.new
+        @new_resource ||= association.build.tap { |new| association.records.delete(new) }
       end
 
       def skipped_fields


### PR DESCRIPTION
Hi !

We encountered an issue recently where we were using NestedHasMany with a polymorphic association that we'd love to fix upstream instead of monkey-patching on our end.

### Problem
Since the new record was instantiated from a simple `associated_class.new`, we had no way of knowing at render time what owner class the record was going to be a child of, and because of that we couldn't customize anything related to that.
Our only option was to build a new model for each of the owner classes, losing the polymorphic association or moving to STI.

### Solution
By building from the owner record's relation instead of the associated class, we get a new record that's prefilled with all the data configured into the association (mainly the `<x>_type` from polymorphic relations and any attributes set by `where`s in the association scope).

This allows us to then customize using that data later on (in our case, to specify a dynamic `collection` for a `Field::Select` depending on the parent record).

Interestingly, [`cocoon` uses a similar pattern](https://github.com/nathanvda/cocoon/blob/b3f4e6d1920937063cba2a4472dc4508bbac00f3/lib/cocoon/view_helpers.rb#L137-L138) to render the link to add a new form.