### PR TITLE
Use nested_form.object in nested_fields_for_builder

### DIFF
--- a/lib/administrate/field/nested_has_many.rb
+++ b/lib/administrate/field/nested_has_many.rb
@@ -39,7 +39,7 @@ module Administrate
           next if nested_field.resource.blank?
 
           # inject current data into field
-          resource = data[form_builder.index]
+          resource = form_builder.object
           nested_field.instance_variable_set(
             "@data",
             resource.send(nested_field.attribute),


### PR DESCRIPTION
I was attempting to render some nested fields for a specific child instance, and caught an edge case in `nested_fields_for_builder`. 

My first attempt:
```erb
<%# Find the administrate nested_has_many attribute for rounds %>
<% round_field = page.attributes.detect{|a| a.attribute == :rounds} %>

<%# This code yanked from nested_has_many _form & _field partials %>
<%= f.fields_for :rounds, @round do |nested_form| %>
  <div class="nested-fields">
    <% round_field.nested_fields_for_builder(nested_form).each do |attribute| -%>
      <div class="field-unit field-unit--<%= attribute.html_class %>">
        <%= render_field attribute, f: nested_form %>
      </div>
    <% end -%>
  </div>
<% end %>
```
By passing in a specific round instance to `f.fields_for :rounds, @round ...`, I would expect the form fields to render with the correct round instance. However, the resource is found like so in `nested_fields_for_builder`
```rb
resource = data[form_builder.index]
```

If you pass an instance to fields_for, the form_builder's instance will always be 0, even though you could be operating on a different child.

I propose to lean on the `form_builder.object` instead, which I believe should always be correctly set to the resource at hand.