### PR TITLE
Pin Administrate below 0.20.0

### DIFF
--- a/administrate-field-nested_has_many.gemspec
+++ b/administrate-field-nested_has_many.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency "administrate", ">= 0.15", "< 1"
+  gem.add_dependency "administrate", ">= 0.15", "< 0.20.0"
   gem.add_dependency "cocoon", "~> 1.2", ">= 1.2.11"
 
   gem.add_development_dependency "appraisal"


### PR DESCRIPTION
0.20.0 introduces a change relating to attribute grouping and makes it incompatible. We'll pin this here and release a new version with this change so that a future breaking change can be marked as such.

https://github.com/nickcharlton/administrate-field-nested_has_many/issues/65