### PR TITLE
Refresh Appraisals

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -4,6 +4,7 @@ appraise "administrate-0.15" do
   gem "administrate", "0.15.0"
 end
 
-appraise "administrate-master" do
-  gem "administrate", git: "https://github.com/thoughtbot/administrate", branch: "master"
+appraise "administrate-0.19" do
+  gem "administrate", "0.19.0"
 end
+


### PR DESCRIPTION
`master` on Administrate is now `main`, so we can't bundle that, but it's also incompatible since #68, so this is an acceptable middleground to let us test for regressions.