### PR TITLE
Drop SQLite development dependency

### DIFF
--- a/administrate-field-nested_has_many.gemspec
+++ b/administrate-field-nested_has_many.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "i18n-tasks"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec-rails"
-  gem.add_development_dependency "sqlite3"
 end

--- a/gemfiles/administrate_0.15.gemfile.lock
+++ b/gemfiles/administrate_0.15.gemfile.lock
@@ -219,8 +219,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.1)
-      mini_portile2 (~> 2.8.0)
     stringio (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -250,7 +248,6 @@ DEPENDENCIES
   rake
   rspec-rails
   selenium-webdriver
-  sqlite3
 
 BUNDLED WITH
    2.5.3

--- a/gemfiles/administrate_0.19.gemfile.lock
+++ b/gemfiles/administrate_0.19.gemfile.lock
@@ -221,12 +221,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.1-aarch64-linux)
-    sqlite3 (1.7.1-arm-linux)
-    sqlite3 (1.7.1-arm64-darwin)
-    sqlite3 (1.7.1-x86-linux)
-    sqlite3 (1.7.1-x86_64-darwin)
-    sqlite3 (1.7.1-x86_64-linux)
     stringio (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -261,7 +255,6 @@ DEPENDENCIES
   rake
   rspec-rails
   selenium-webdriver
-  sqlite3
 
 BUNDLED WITH
    2.5.3


### PR DESCRIPTION
On CI, we run using Postgres and so this shouldn't be necessary. It
should fix this failure:

        sqlite3-1.7.1-x86_64-linux requires ruby version < 3.4.dev, >= 3.0, which is
        incompatible with the current version, ruby 2.7.0p0