### PR TITLE
Allow i18n on add/remove links

### DIFF
--- a/app/views/fields/nested_has_many/_fields.html.erb
+++ b/app/views/fields/nested_has_many/_fields.html.erb
@@ -5,5 +5,5 @@
     </div>
   <% end -%>
 
-  <%= link_to_remove_association I18n.t("administrate.fields.nested_has_many.remove", resource: field.associated_class_name.titleize), f %>
+  <%= link_to_remove_association f %>
 </div>

--- a/app/views/fields/nested_has_many/_form.html.erb
+++ b/app/views/fields/nested_has_many/_form.html.erb
@@ -12,7 +12,6 @@
 
   <div>
     <%= link_to_add_association(
-      I18n.t("administrate.fields.nested_has_many.add", resource: field.associated_class_name.titleize),
       f,
       field.association_name,
       class: 'button',

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -6,3 +6,6 @@ data:
 
 ignore:
   - 'administrate.fields.has_many.*'
+  - 'cocoon.defaults.*'
+  - 'cocoon.foo/students.*'
+  - 'cocoon.students.*'

--- a/config/locales/administrate-field-nested_has_many.de.yml
+++ b/config/locales/administrate-field-nested_has_many.de.yml
@@ -1,7 +1,6 @@
 ---
 de:
-  administrate:
-    fields:
-      nested_has_many:
-        add: "%{resource} hinzufügen"
-        remove: "%{resource} entfernen"
+  cocoon:
+    defaults:
+      add: Datensatz hinzufügen
+      remove: Datensatz entfernen

--- a/config/locales/administrate-field-nested_has_many.en.yml
+++ b/config/locales/administrate-field-nested_has_many.en.yml
@@ -1,7 +1,10 @@
 ---
 en:
-  administrate:
-    fields:
-      nested_has_many:
-        add: Add %{resource}
-        remove: Remove %{resource}
+  cocoon:
+    defaults:
+      add: Add record
+      remove: Remove record
+    foo/students:
+      remove: Remove Foo/Student
+    students:
+      add: Add Foo/Student

--- a/config/locales/administrate-field-nested_has_many.fr.yml
+++ b/config/locales/administrate-field-nested_has_many.fr.yml
@@ -1,7 +1,6 @@
 ---
 fr:
-  administrate:
-    fields:
-      nested_has_many:
-        add: Ajouter %{resource}
-        remove: Supprimer %{resource}
+  cocoon:
+    defaults:
+      add: Ajouter un enregistrement
+      remove: Supprimer un enregistrement

--- a/config/locales/administrate-field-nested_has_many.ja.yml
+++ b/config/locales/administrate-field-nested_has_many.ja.yml
@@ -1,7 +1,6 @@
 ---
 ja:
-  administrate:
-    fields:
-      nested_has_many:
-        add: "%{resource}を追加"
-        remove: "%{resource}を削除"
+  cocoon:
+    defaults:
+      add: レコードを追加
+      remove: レコードを削除

--- a/config/locales/administrate-field-nested_has_many.pt.yml
+++ b/config/locales/administrate-field-nested_has_many.pt.yml
@@ -1,7 +1,6 @@
 ---
 pt:
-  administrate:
-    fields:
-      nested_has_many:
-        add: Adicionar %{resource}
-        remove: Remover %{resource}
+  cocoon:
+    defaults:
+      add: Adicionar registro
+      remove: Remover registro

--- a/config/locales/administrate-field-nested_has_many.ru.yml
+++ b/config/locales/administrate-field-nested_has_many.ru.yml
@@ -1,7 +1,6 @@
 ---
 ru:
-  administrate:
-    fields:
-      nested_has_many:
-        add: Добавить %{resource}
-        remove: Удалить %{resource}
+  cocoon:
+    defaults:
+      add: Добавить запись
+      remove: Удалить запись


### PR DESCRIPTION
Note: breaking changes.

The limitation of the current implementation means that the add/remove links cannot be i18n'ed if the resource name also needs translation.

This PR addresses this, although, as a consequence, by default the translation for all links are fixed as seen in the `defaults` section in the yaml files, and individual ones need to be added to them.