### PR TITLE
Make sure @resource is also set for nested fields

### DIFF
--- a/lib/administrate/field/nested_has_many.rb
+++ b/lib/administrate/field/nested_has_many.rb
@@ -50,6 +50,10 @@ module Administrate
             "@data",
             resource.send(nested_field.attribute),
           )
+          nested_field.instance_variable_set(
+            "@resource",
+            resource
+          )
         end
       end
 


### PR DESCRIPTION
Hey @nickcharlton - long time since we've interacted on Administrate-related things!

I love this gem and it's been really useful in my latest project. One bug I found is that if any of the fields from the associated dashboard use `self.resource`, they end up picking up the parent resource instead of the nested one.

You'd already used `instance_variable_set` to set the `self.data` and so I propose that the gem uses the same methodology to set `resource`.

I've tested this fix in my app that has a full test suite and it hasn't broken any of the tests in that app. I couldn't get the gem's tests to run because they depend on a postgres database, which I don't have, but I couldn't see a place in the tests for defending this change anyway - the earlier `@data` setting doesn't appear to have a test defending it.

Let me know what you think!