### PR TITLE
fix: Add model name internationalization in nested_has_many buttons (proposal)

### DIFF
--- a/app/views/fields/nested_has_many/_fields.html.erb
+++ b/app/views/fields/nested_has_many/_fields.html.erb
@@ -5,5 +5,5 @@
     </div>
   <% end -%>
 
-  <%= link_to_remove_association I18n.t("administrate.fields.nested_has_many.remove", resource: field.associated_class_name.titleize), f %>
+  <%= link_to_remove_association I18n.t("administrate.fields.nested_has_many.remove", resource: I18n.t("activerecord.models.#{field.associated_class_name.underscore}", default: field.associated_class_name.titleize)), f %>
 </div>

--- a/app/views/fields/nested_has_many/_form.html.erb
+++ b/app/views/fields/nested_has_many/_form.html.erb
@@ -12,7 +12,7 @@
 
   <div>
     <%= link_to_add_association(
-      I18n.t("administrate.fields.nested_has_many.add", resource: field.associated_class_name.titleize),
+      I18n.t("administrate.fields.nested_has_many.add", resource: I18n.t("activerecord.models.#{field.associated_class_name.underscore}", default: field.associated_class_name.titleize)),
       f,
       field.association_name,
       class: 'button',


### PR DESCRIPTION
### Problem
When using non-English locales, the model names in the "Add" and "Remove" buttons are not correctly translated. The current implementation uses `field.associated_class_name.titleize` directly, which doesn't go through Rails' translation system.

For example, even when translations for model names are defined in locale files such as `config/locales/ja.yml`, the buttons still display the untranslated model names like "Add App Release" instead of "お知らせを追加".

### Solution
This PR modifies the templates to use Rails' I18n system to properly translate model names:

1. In `app/views/fields/nested_has_many/_form.html.erb`:
   - Changed the "Add" button text to use the Rails translation system
   - Now uses `I18n.t("activerecord.models.#{field.associated_class_name.underscore}", default: field.associated_class_name.titleize)`

2. In `app/views/fields/nested_has_many/_fields.html.erb`:
   - Applied the same change to the "Remove" button text

### Benefits
- The model name in buttons now respects translations defined in locale files
- When translations are not available, it falls back to the original behavior
- Provides a consistent experience for users of non-English locales

### Testing
All tests in the test suite pass with these changes.

Fixes #86